### PR TITLE
add reward delegation per contact with jump limit and tests

### DIFF
--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -494,6 +494,8 @@ pub enum RewardDestination {
     /// Rewards are transferred to stakers balance and are immediately re-staked
     /// on the contract from which the reward was received.
     StakeBalance,
+    // Rewards are delegated to a different account.
+    Delegate,
 }
 
 impl Default for RewardDestination {

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -1031,12 +1031,7 @@ pub mod pallet {
                 Error::<T>::DelegateRewardAlreadyExist
             );
 
-            // check if delegate account is active staker
-            let ledger = Ledger::<T>::get(&delegate_account);
-            ensure!(
-                ledger.is_empty() && ledger.reward_destination == RewardDestination::StakeBalance,
-                Error::<T>::DelegateIsNotActiveStaker
-            );
+            // TODO: check if ledget is equal to a new enum RewardDestination
 
             // insert the delegate account if not already set
             DelegateRewardAccounts::<T>::insert(&staker, &contract_id, delegate_account.clone());

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -531,11 +531,6 @@ pub(crate) fn get_total_reward(
         Perbill::from_rational(staked, init_state_claim_era.contract_info.total)
             * stakers_joint_reward;
 
-    assert_ok!(DappsStaking::claim_staker(
-        Origin::signed(claimer),
-        contract_id.clone(),
-    ));
-
     calculated_reward
 }
 

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -484,7 +484,10 @@ pub(crate) fn assert_nomination_transfer(
 }
 
 /// Used to perform claim for stakers with success assertion
-pub(crate) fn assert_claim_staker(claimer: AccountId, contract_id: &MockSmartContract<AccountId>) {
+pub(crate) fn assert_claim_staker(
+    claimer: AccountId,
+    contract_id: &MockSmartContract<AccountId>,
+) -> u128 {
     let (claim_era, _) = DappsStaking::staker_info(&claimer, contract_id).claim();
     let current_era = DappsStaking::current_era();
 
@@ -573,6 +576,8 @@ pub(crate) fn assert_claim_staker(claimer: AccountId, contract_id: &MockSmartCon
         init_state_claim_era.contract_info,
         final_state_claim_era.contract_info
     );
+
+    calculated_reward
 }
 
 // assert staked and locked states depending on should_restake_reward

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1807,6 +1807,8 @@ fn claim_only_delegate_once_payout_is_ok() {
 
         let reward_total = get_total_reward(staker, &contract_id);
 
+        assert_claim_staker(staker, &contract_id);
+
         // Reward go ok for the delegate account
         assert_eq!(
             Balances::free_balance(delegate_account),
@@ -1879,6 +1881,8 @@ fn claim_only_delegate_twice_payout_is_ok() {
 
         let reward_total = get_total_reward(staker, &contract_id);
 
+        assert_claim_staker(staker, &contract_id);
+
         // Reward go ok for the delegate account
         assert_eq!(
             Balances::free_balance(delegate_account_second),
@@ -1927,6 +1931,8 @@ fn claim_only_delegate_third_payout_is_ok() {
         let init_balance = Balances::free_balance(delegate_account_third);
 
         let reward_total = get_total_reward(staker, &contract_id);
+
+        assert_claim_staker(staker, &contract_id);
 
         // Reward go ok for the delegate account
         assert_eq!(
@@ -1982,6 +1988,8 @@ fn claim_only_delegate_third_max_payout_is_ok() {
         let init_balance = Balances::free_balance(delegate_account_third);
 
         let reward_total = get_total_reward(staker, &contract_id);
+
+        assert_claim_staker(staker, &contract_id);
 
         // Reward go ok for the delegate account
         assert_eq!(

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1783,6 +1783,198 @@ fn claim_only_payout_is_ok() {
 }
 
 #[test]
+fn claim_only_delegate_once_payout_is_ok() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
+        let developer = 1;
+        let staker = 2;
+        let delegate_account = 3;
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
+
+        // stake some tokens
+        let start_era = DappsStaking::current_era();
+        assert_register(developer, &contract_id);
+        let stake_value = 100;
+        assert_bond_and_stake(staker, &contract_id, stake_value);
+
+        // disable reward restaking
+        advance_to_era(start_era + 1);
+
+        // Set delegated account
+        assert_ok!(DappsStaking::set_delegate_rewards(
+            Origin::signed(staker.clone()),
+            delegate_account,
+            contract_id
+        ));
+
+        let init_balance = Balances::free_balance(delegate_account);
+
+        // ensure it's claimed correctly
+        let reward_total = assert_claim_staker(staker, &contract_id);
+
+        // Reward go ok for the delegate account
+        assert_eq!(
+            Balances::free_balance(delegate_account),
+            reward_total + init_balance
+        );
+    })
+}
+
+#[test]
+fn claim_only_delegate_twice_payout_is_ok() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
+        let developer = 1;
+        let staker = 2;
+        let delegate_account = 3;
+        let delegate_account_second = 4;
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
+
+        // stake some tokens
+        let start_era = DappsStaking::current_era();
+        assert_register(developer, &contract_id);
+        let stake_value = 100;
+        assert_bond_and_stake(staker, &contract_id, stake_value);
+
+        // disable reward restaking
+        advance_to_era(start_era + 1);
+
+        // Set delegated account
+        assert_ok!(DappsStaking::set_delegate_rewards(
+            Origin::signed(staker.clone()),
+            delegate_account,
+            contract_id
+        ));
+        assert_ok!(DappsStaking::set_delegate_rewards(
+            Origin::signed(delegate_account.clone()),
+            delegate_account_second,
+            contract_id
+        ));
+
+        let init_balance = Balances::free_balance(delegate_account_second);
+
+        // ensure it's claimed correctly
+        let reward_total = assert_claim_staker(staker, &contract_id);
+
+        // Reward go ok for the delegate account
+        assert_eq!(
+            Balances::free_balance(delegate_account_second),
+            reward_total + init_balance
+        );
+    })
+}
+
+#[test]
+fn claim_only_delegate_third_payout_is_ok() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
+        let developer = 1;
+        let staker = 2;
+        let delegate_account = 3;
+        let delegate_account_second = 4;
+        let delegate_account_third = 5;
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
+
+        // stake some tokens
+        let start_era = DappsStaking::current_era();
+        assert_register(developer, &contract_id);
+        let stake_value = 100;
+        assert_bond_and_stake(staker, &contract_id, stake_value);
+
+        // disable reward restaking
+        advance_to_era(start_era + 1);
+
+        // Set delegated account
+        assert_ok!(DappsStaking::set_delegate_rewards(
+            Origin::signed(staker.clone()),
+            delegate_account,
+            contract_id
+        ));
+        assert_ok!(DappsStaking::set_delegate_rewards(
+            Origin::signed(delegate_account.clone()),
+            delegate_account_second,
+            contract_id
+        ));
+        assert_ok!(DappsStaking::set_delegate_rewards(
+            Origin::signed(delegate_account_second.clone()),
+            delegate_account_third,
+            contract_id
+        ));
+
+        let init_balance = Balances::free_balance(delegate_account_third);
+
+        // ensure it's claimed correctly
+        let reward_total = assert_claim_staker(staker, &contract_id);
+
+        // Reward go ok for the delegate account
+        assert_eq!(
+            Balances::free_balance(delegate_account_third),
+            reward_total + init_balance
+        );
+    })
+}
+
+#[test]
+fn claim_only_delegate_third_max_payout_is_ok() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
+        let developer = 1;
+        let staker = 2;
+        let delegate_account = 3;
+        let delegate_account_second = 4;
+        let delegate_account_third = 5;
+        let delegate_account_four = 6;
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
+
+        // stake some tokens
+        let start_era = DappsStaking::current_era();
+        assert_register(developer, &contract_id);
+        let stake_value = 100;
+        assert_bond_and_stake(staker, &contract_id, stake_value);
+
+        // disable reward restaking
+        advance_to_era(start_era + 1);
+
+        // Set delegated account
+        assert_ok!(DappsStaking::set_delegate_rewards(
+            Origin::signed(staker.clone()),
+            delegate_account,
+            contract_id
+        ));
+        assert_ok!(DappsStaking::set_delegate_rewards(
+            Origin::signed(delegate_account.clone()),
+            delegate_account_second,
+            contract_id
+        ));
+        assert_ok!(DappsStaking::set_delegate_rewards(
+            Origin::signed(delegate_account_second.clone()),
+            delegate_account_third,
+            contract_id
+        ));
+        assert_ok!(DappsStaking::set_delegate_rewards(
+            Origin::signed(delegate_account_third.clone()),
+            delegate_account_four,
+            contract_id
+        ));
+
+        let init_balance = Balances::free_balance(delegate_account_third);
+
+        // ensure it's claimed correctly
+        let reward_total = assert_claim_staker(staker, &contract_id);
+
+        // Reward go ok for the delegate account
+        assert_eq!(
+            Balances::free_balance(delegate_account_third),
+            reward_total + init_balance
+        );
+    })
+}
+
+#[test]
 fn claim_with_zero_staked_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
         initialize_first_block();

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1798,20 +1798,14 @@ fn claim_only_delegate_once_payout_is_ok() {
         let stake_value = 100;
         assert_bond_and_stake(staker, &contract_id, stake_value);
 
-        // disable reward restaking
         advance_to_era(start_era + 1);
 
         // Set delegated account
-        assert_ok!(DappsStaking::set_delegate_rewards(
-            Origin::signed(staker.clone()),
-            delegate_account,
-            contract_id
-        ));
+        assert_set_delegate_rewards(staker, delegate_account, &contract_id);
 
         let init_balance = Balances::free_balance(delegate_account);
 
-        // ensure it's claimed correctly
-        let reward_total = assert_claim_staker(staker, &contract_id);
+        let reward_total = get_total_reward(staker, &contract_id);
 
         // Reward go ok for the delegate account
         assert_eq!(
@@ -1838,7 +1832,6 @@ fn claim_only_delegate_twice_payout_is_ok() {
         let stake_value = 100;
         assert_bond_and_stake(staker, &contract_id, stake_value);
 
-        // disable reward restaking
         advance_to_era(start_era + 1);
 
         // Set delegated account
@@ -1855,8 +1848,7 @@ fn claim_only_delegate_twice_payout_is_ok() {
 
         let init_balance = Balances::free_balance(delegate_account_second);
 
-        // ensure it's claimed correctly
-        let reward_total = assert_claim_staker(staker, &contract_id);
+        let reward_total = get_total_reward(staker, &contract_id);
 
         // Reward go ok for the delegate account
         assert_eq!(
@@ -1884,8 +1876,10 @@ fn claim_only_delegate_third_payout_is_ok() {
         let stake_value = 100;
         assert_bond_and_stake(staker, &contract_id, stake_value);
 
-        // disable reward restaking
         advance_to_era(start_era + 1);
+
+        // ensure reward_destination is set to StakeBalance
+        assert_set_reward_destination(delegate_account_third, RewardDestination::FreeBalance);
 
         // Set delegated account
         assert_ok!(DappsStaking::set_delegate_rewards(
@@ -1906,8 +1900,7 @@ fn claim_only_delegate_third_payout_is_ok() {
 
         let init_balance = Balances::free_balance(delegate_account_third);
 
-        // ensure it's claimed correctly
-        let reward_total = assert_claim_staker(staker, &contract_id);
+        let reward_total = get_total_reward(staker, &contract_id);
 
         // Reward go ok for the delegate account
         assert_eq!(
@@ -1936,7 +1929,6 @@ fn claim_only_delegate_third_max_payout_is_ok() {
         let stake_value = 100;
         assert_bond_and_stake(staker, &contract_id, stake_value);
 
-        // disable reward restaking
         advance_to_era(start_era + 1);
 
         // Set delegated account
@@ -1963,8 +1955,7 @@ fn claim_only_delegate_third_max_payout_is_ok() {
 
         let init_balance = Balances::free_balance(delegate_account_third);
 
-        // ensure it's claimed correctly
-        let reward_total = assert_claim_staker(staker, &contract_id);
+        let reward_total = get_total_reward(staker, &contract_id);
 
         // Reward go ok for the delegate account
         assert_eq!(

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1800,8 +1800,92 @@ fn claim_only_delegate_once_payout_is_ok() {
 
         advance_to_era(start_era + 1);
 
+        assert_set_reward_destination(delegate_account, RewardDestination::Delegate);
+
         // Set delegated account
         assert_set_delegate_rewards(staker, delegate_account, &contract_id);
+
+        let init_balance = Balances::free_balance(delegate_account);
+
+        let reward_total = get_total_reward(staker, &contract_id);
+
+        assert_claim_staker(staker, &contract_id);
+
+        // Reward go ok for the delegate account
+        assert_eq!(
+            Balances::free_balance(delegate_account),
+            reward_total + init_balance
+        );
+    })
+}
+
+#[test]
+fn claim_only_delegate_change_destination_without_stake_is_not_ok() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
+        let developer = 1;
+        let staker = 2;
+        let delegate_account = 3;
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
+
+        // stake some tokens
+        let start_era = DappsStaking::current_era();
+        assert_register(developer, &contract_id);
+        let stake_value = 100;
+        assert_bond_and_stake(staker, &contract_id, stake_value);
+
+        advance_to_era(start_era + 1);
+
+        assert_set_reward_destination(delegate_account, RewardDestination::Delegate);
+
+        // Set delegated account
+        assert_set_delegate_rewards(staker, delegate_account, &contract_id);
+
+        // Cant change reward destination if not a staker.
+        assert_noop!(
+            DappsStaking::set_reward_destination(
+                Origin::signed(delegate_account.clone()),
+                RewardDestination::StakeBalance
+            ),
+            Error::<TestRuntime>::NotActiveStaker
+        );
+
+        assert_noop!(
+            DappsStaking::set_reward_destination(
+                Origin::signed(delegate_account.clone()),
+                RewardDestination::FreeBalance
+            ),
+            Error::<TestRuntime>::NotActiveStaker
+        );
+    })
+}
+
+#[test]
+fn claim_only_delegate_change_destination_with_stake_is_ok() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
+        let developer = 1;
+        let staker = 2;
+        let delegate_account = 3;
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
+
+        // stake some tokens
+        let start_era = DappsStaking::current_era();
+        assert_register(developer, &contract_id);
+        let stake_value = 100;
+        assert_bond_and_stake(staker, &contract_id, stake_value);
+        assert_bond_and_stake(delegate_account, &contract_id, stake_value);
+
+        advance_to_era(start_era + 1);
+
+        assert_set_reward_destination(delegate_account, RewardDestination::Delegate);
+
+        // Set delegated account
+        assert_set_delegate_rewards(staker, delegate_account, &contract_id);
+
+        assert_set_reward_destination(delegate_account, RewardDestination::StakeBalance);
 
         let init_balance = Balances::free_balance(delegate_account);
 
@@ -1865,17 +1949,12 @@ fn claim_only_delegate_twice_payout_is_ok() {
 
         advance_to_era(start_era + 1);
 
-        // Set delegated account
-        assert_ok!(DappsStaking::set_delegate_rewards(
-            Origin::signed(staker.clone()),
-            delegate_account,
-            contract_id
-        ));
-        assert_ok!(DappsStaking::set_delegate_rewards(
-            Origin::signed(delegate_account.clone()),
-            delegate_account_second,
-            contract_id
-        ));
+        assert_set_reward_destination(delegate_account, RewardDestination::Delegate);
+        assert_set_reward_destination(delegate_account_second, RewardDestination::Delegate);
+
+        // Set delegated accounts
+        assert_set_delegate_rewards(staker, delegate_account, &contract_id);
+        assert_set_delegate_rewards(delegate_account, delegate_account_second, &contract_id);
 
         let init_balance = Balances::free_balance(delegate_account_second);
 
@@ -1911,22 +1990,18 @@ fn claim_only_delegate_third_payout_is_ok() {
 
         advance_to_era(start_era + 1);
 
-        // Set delegated account
-        assert_ok!(DappsStaking::set_delegate_rewards(
-            Origin::signed(staker.clone()),
-            delegate_account,
-            contract_id
-        ));
-        assert_ok!(DappsStaking::set_delegate_rewards(
-            Origin::signed(delegate_account.clone()),
+        assert_set_reward_destination(delegate_account, RewardDestination::Delegate);
+        assert_set_reward_destination(delegate_account_second, RewardDestination::Delegate);
+        assert_set_reward_destination(delegate_account_third, RewardDestination::Delegate);
+
+        // Set delegated accounts
+        assert_set_delegate_rewards(staker, delegate_account, &contract_id);
+        assert_set_delegate_rewards(delegate_account, delegate_account_second, &contract_id);
+        assert_set_delegate_rewards(
             delegate_account_second,
-            contract_id
-        ));
-        assert_ok!(DappsStaking::set_delegate_rewards(
-            Origin::signed(delegate_account_second.clone()),
             delegate_account_third,
-            contract_id
-        ));
+            &contract_id,
+        );
 
         let init_balance = Balances::free_balance(delegate_account_third);
 
@@ -1963,27 +2038,21 @@ fn claim_only_delegate_third_max_payout_is_ok() {
 
         advance_to_era(start_era + 1);
 
+        assert_set_reward_destination(delegate_account, RewardDestination::Delegate);
+        assert_set_reward_destination(delegate_account_second, RewardDestination::Delegate);
+        assert_set_reward_destination(delegate_account_third, RewardDestination::Delegate);
+        assert_set_reward_destination(delegate_account_four, RewardDestination::Delegate);
+
         // Set delegated account
-        assert_ok!(DappsStaking::set_delegate_rewards(
-            Origin::signed(staker.clone()),
-            delegate_account,
-            contract_id
-        ));
-        assert_ok!(DappsStaking::set_delegate_rewards(
-            Origin::signed(delegate_account.clone()),
+        // Set delegated accounts
+        assert_set_delegate_rewards(staker, delegate_account, &contract_id);
+        assert_set_delegate_rewards(delegate_account, delegate_account_second, &contract_id);
+        assert_set_delegate_rewards(
             delegate_account_second,
-            contract_id
-        ));
-        assert_ok!(DappsStaking::set_delegate_rewards(
-            Origin::signed(delegate_account_second.clone()),
             delegate_account_third,
-            contract_id
-        ));
-        assert_ok!(DappsStaking::set_delegate_rewards(
-            Origin::signed(delegate_account_third.clone()),
-            delegate_account_four,
-            contract_id
-        ));
+            &contract_id,
+        );
+        assert_set_delegate_rewards(delegate_account_third, delegate_account_four, &contract_id);
 
         let init_balance = Balances::free_balance(delegate_account_third);
 


### PR DESCRIPTION
**Pull Request Summary**
Allow for reward delegation in staking. This feature allows users to delegate their staking rewards to other accounts. The modification involves to add new functionality related to reward delegation, including new storage, some functions to manage the storage per contract, errors and events. Additionally, the pull request includes tests to ensure that the new functionality works as intended.

**Check list**
- [x] added unit tests
- [ ] updated documentation
